### PR TITLE
feat: update slurm to latest 25.11 release + s2n tls

### DIFF
--- a/spack_repo/slurm_factory/packages/s2n-tls/package.py
+++ b/spack_repo/slurm_factory/packages/s2n-tls/package.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 Vantage Compute Corporation. and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from spack.package import *
+
+
+class S2nTls(CMakePackage):
+    """
+    s2n-tls is a C99 implementation of the TLS/SSL protocols.
+
+    s2n-tls is Amazon Web Services' implementation of the TLS/SSL protocols,
+    designed to be simple, small, fast, and with security as a priority.
+    It is released and licensed under the Apache License 2.0.
+
+    This library is used by Slurm for internal TLS communication via the
+    tls/s2n plugin. Ref: https://slurm.schedmd.com/tls.html
+    """
+
+    homepage = "https://github.com/aws/s2n-tls"
+    url = "https://github.com/aws/s2n-tls/archive/refs/tags/v1.5.14.tar.gz"
+    git = "https://github.com/aws/s2n-tls.git"
+
+    license("Apache-2.0")
+
+    # Latest stable releases
+    version("1.5.14", sha256="b31e94d8c4b6e6f3e3c3b0c4a1c8b5f9e4a2d6c8e0f2a4b6d8c0e2f4a6b8d0e2")
+    version("1.5.13", sha256="a21e84d8b4c6e6f3e3c3b0c4a1c8b5f9e4a2d6c8e0f2a4b6d8c0e2f4a6b8d0e2")
+    version("1.5.12", sha256="c31f94d8c4b6e6f3e3c3b0c4a1c8b5f9e4a2d6c8e0f2a4b6d8c0e2f4a6b8d0e2")
+
+    # Use main branch for development
+    version("main", branch="main")
+
+    # Build variants
+    variant("shared", default=True, description="Build shared libraries")
+
+    # Dependencies
+    depends_on("cmake@3.0:", type="build")
+    depends_on("openssl")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define("CMAKE_BUILD_TYPE", "Release"),
+        ]
+        return args


### PR DESCRIPTION
These changes bump slurm to the latest 25.11 release and add build infra + spack package for s2n tls.