### PR TITLE
fix: Update slurm package.py for Spack 1.0 API compatibility

### DIFF
--- a/spack_repo/slurm_factory/packages/slurm/package.py
+++ b/spack_repo/slurm_factory/packages/slurm/package.py
@@ -16,7 +16,7 @@ import re
 
 import spack.llnl.util.tty as tty
 import spack.util.executable as exe
-from spack.build_systems.autotools import AutotoolsPackage
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack.package import *
 from spack.util.executable import which
 


### PR DESCRIPTION
## Summary
Fix Spack 1.0 API compatibility for the slurm package.

## Problem
Builds were failing with the error:
```
cannot load package 'slurm' from the 'slurm_factory' repository: No module named 'spack.build_systems'
```

This is because Spack 1.0 reorganized the build systems module structure. The old import path `spack.build_systems` was moved to `spack_repo.builtin.build_systems`.

## Fix
Changed the import statement on line 19:
```python
# Before (Spack 0.x)
from spack.build_systems.autotools import AutotoolsPackage

# After (Spack 1.0)
from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
```

## Testing
- Verified the fix in a running build container by manually editing the file
- Confirmed `spack info slurm_factory.slurm` works correctly after the fix
- Confirmed concretization succeeds with `spack spec slurm_factory.slurm@25-11-2-1`

## Notes
Other packages in this repo (curl, freeipmi, openssl, s2n_tls) already use the correct Spack 1.0 import paths - only the slurm package.py was using the old style.