### PR TITLE
fix: use working_dir() instead of cwd parameter for Spack 1.0 compatibility

### DIFF
--- a/spack_repo/slurm_factory/packages/slurm/package.py
+++ b/spack_repo/slurm_factory/packages/slurm/package.py
@@ -405,16 +405,21 @@ Cflags: -I${{includedir}}
 
         tty.msg(f"Configuring s2n-tls with cmake in {s2n_build}")
         cmake = which("cmake")
-        cmake(*cmake_args, cwd=s2n_build)
+        # Spack 1.0 API: use working_dir context manager instead of cwd parameter
+        with working_dir(s2n_build):
+            cmake(*cmake_args)
 
         # Build s2n-tls
         tty.msg("Building s2n-tls")
         make = which("make")
-        make("-j4", cwd=s2n_build)
+        # Spack 1.0 API: use working_dir context manager instead of cwd parameter
+        with working_dir(s2n_build):
+            make("-j4")
 
         # Install s2n-tls
         tty.msg(f"Installing s2n-tls to {s2n_prefix}")
-        make("install", cwd=s2n_build)
+        with working_dir(s2n_build):
+            make("install")
 
         # Verify installation
         s2n_lib = join_path(s2n_prefix, "lib", "libs2n.so")


### PR DESCRIPTION
## Summary

Fix Spack 1.0 API compatibility issue in the `build_s2n_tls()` method.

## Problem

Spack 1.0 changed the `Executable` API - the `__call__()` method no longer accepts a `cwd` keyword argument:

```
TypeError: Executable.__call__() got an unexpected keyword argument 'cwd'
```

This error occurs at line 408 when building s2n-tls for Slurm 25.11:

```python
cmake(*cmake_args, cwd=s2n_build)  # ❌ Fails in Spack 1.0
```

## Solution

Use the `working_dir()` context manager from `spack.package` instead of the `cwd` parameter:

```python
with working_dir(s2n_build):
    cmake(*cmake_args)  # ✅ Works in Spack 1.0
```

## Changes

- Updated `build_s2n_tls()` method to use `working_dir()` context manager for:
  - CMake configuration
  - Make build
  - Make install

## Testing

This fix should be tested with:
```bash
uv run slurm-factory build-slurm --slurm-version 25.11 --toolchain jammy --gpu --no-cache
```

## Related

- This is part of the Spack 1.0 migration effort
- Previous fix (PR #11) addressed the import path change from `spack.build_systems` to `spack_repo.builtin.build_systems`